### PR TITLE
[feat]: Add model selection, dynamic model fetch, and enhanced API key UI

### DIFF
--- a/src/llm/types/openai.ts
+++ b/src/llm/types/openai.ts
@@ -1,25 +1,26 @@
 import {
   ImageChatMessageContent,
+  LLMProviders,
   TextChatMessageContent,
 } from '@/llm/provider/base';
+import { getStoredApiKey } from '@/main';
 // https://platform.openai.com/docs/models/model-endpoint-compatibility
 // Define a type for the acceptable model names
 export type OpenAiTextModelNames =
-  | 'chatgpt-4o-latest'
-  | 'gpt-4o-2024-08-06'
+  | 'gpt-4.1-nano'
+  | 'gpt-4.1-preview'
+  | 'gpt-4.1'
+  | 'gpt-4o'
   | 'gpt-4o-mini'
   | 'gpt-4'
   | 'gpt-3.5-turbo'
-  | 'gpt-4o'
-  | 'gpt-3.5-turbo-preview'
-  | 'gpt-3.5-turbo-1106';
+  | 'gpt-3.5-turbo-instruct';
 
 export type OpenAiModelNames =
   | OpenAiTextModelNames
   | 'whisper-1'
   | 'tts-1'
   | 'tts-1-hd'
-  | 'gpt-3.5-turbo-instruct'
   | 'babbage-002'
   | 'davinci-002'
   | 'text-embedding-3-small'
@@ -42,29 +43,100 @@ export type OpenAiEndpoint =
   | '/v1/moderations'
   | '/v1/images/generations';
 
+// Function to fetch available models from OpenAI API
+export async function fetchAvailableModels(
+  provider: LLMProviders
+): Promise<string[]> {
+  try {
+    const apiKey = getStoredApiKey(provider);
+    const response = UrlFetchApp.fetch('https://api.openai.com/v1/models', {
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      muteHttpExceptions: true,
+    });
+
+    const responseCode = response.getResponseCode();
+    if (responseCode !== 200) {
+      console.error(`Failed to fetch models: ${responseCode}`);
+      return getDefaultChatModels(provider);
+    }
+
+    const jsonResponse = JSON.parse(response.getContentText());
+    const models = jsonResponse.data
+      .map((model: any) => model.id)
+      .filter(
+        (modelId: string) =>
+          modelId.startsWith('gpt-') &&
+          !modelId.includes('instruct') &&
+          !modelId.includes('vision') &&
+          !modelId.includes('embedding')
+      );
+
+    return models.length > 0 ? models : getDefaultChatModels(provider);
+  } catch (error) {
+    console.error('Error fetching models:', error);
+    return getDefaultChatModels(provider);
+  }
+}
+
+// Default chat models if API call fails
+export function getDefaultChatModels(
+  provider: LLMProviders
+): OpenAiTextModelNames[] {
+  switch (provider) {
+    case 'openai':
+      return [
+        'gpt-4.1-nano',
+        'gpt-4.1-preview',
+        'gpt-4.1',
+        'gpt-4o',
+        'gpt-4o-mini',
+        'gpt-4',
+        'gpt-3.5-turbo',
+      ];
+    default:
+      return ['gpt-4.1-nano'];
+  }
+}
+/**
+ * Get the default model for a given provider
+ * @param provider The provider to get the default model for
+ * @returns The default model for the given provider
+ */
+export function getDefaultModel(provider: LLMProviders): OpenAiTextModelNames {
+  switch (provider) {
+    case 'openai':
+      return 'gpt-4.1-nano';
+    default:
+      return 'gpt-4.1-nano';
+  }
+}
+
 // Define an object that maps endpoints to acceptable models
 export const EndpointModelMapping: Record<OpenAiEndpoint, OpenAiModelNames[]> =
   {
     '/v1/assistants': [
-      'chatgpt-4o-latest',
+      'gpt-4.1-nano',
+      'gpt-4.1-preview',
+      'gpt-4.1',
+      'gpt-4o',
       'gpt-4o-mini',
       'gpt-4',
       'gpt-3.5-turbo',
-      'gpt-4o',
-      'gpt-3.5-turbo-preview',
-      'gpt-3.5-turbo-1106',
-      'gpt-4o-2024-08-06',
     ],
     '/v1/audio/transcriptions': ['whisper-1'],
     '/v1/audio/translations': ['whisper-1'],
     '/v1/audio/speech': ['tts-1', 'tts-1-hd'],
     '/v1/chat/completions': [
-      'chatgpt-4o-latest',
+      'gpt-4.1-nano',
+      'gpt-4.1-preview',
+      'gpt-4.1',
+      'gpt-4o',
       'gpt-4o-mini',
       'gpt-4',
       'gpt-3.5-turbo',
-      'gpt-4o',
-      'gpt-4o-2024-08-06',
     ],
     '/v1/completions (Legacy)': [
       'gpt-3.5-turbo-instruct',
@@ -77,6 +149,7 @@ export const EndpointModelMapping: Record<OpenAiEndpoint, OpenAiModelNames[]> =
       'text-embedding-ada-002',
     ],
     '/v1/fine_tuning/jobs': [
+      'gpt-4.1',
       'gpt-4o',
       'gpt-4o-mini',
       'gpt-4',
@@ -87,42 +160,37 @@ export const EndpointModelMapping: Record<OpenAiEndpoint, OpenAiModelNames[]> =
     '/v1/moderations': ['text-moderation-stable', 'text-moderation-latest'],
     '/v1/images/generations': ['dall-e-2', 'dall-e-3'],
   };
-export const ModelEndpointMapping: Record<OpenAiModelNames, OpenAiEndpoint[]> =
-  {
-    'chatgpt-4o-latest': ['/v1/assistants', '/v1/chat/completions'],
-    'gpt-4o-2024-08-06': ['/v1/assistants', '/v1/chat/completions'],
-    'gpt-4o-mini': [
-      '/v1/assistants',
-      '/v1/chat/completions',
-      '/v1/fine_tuning/jobs',
-    ],
-    'gpt-4': ['/v1/assistants', '/v1/chat/completions', '/v1/fine_tuning/jobs'],
-    'gpt-3.5-turbo': [
-      '/v1/assistants',
-      '/v1/chat/completions',
-      '/v1/fine_tuning/jobs',
-    ],
-    'gpt-4o': [
-      '/v1/assistants',
-      '/v1/chat/completions',
-      '/v1/fine_tuning/jobs',
-    ],
-    'gpt-3.5-turbo-preview': ['/v1/assistants'],
-    'gpt-3.5-turbo-1106': ['/v1/assistants'],
-    'whisper-1': ['/v1/audio/transcriptions', '/v1/audio/translations'],
-    'tts-1': ['/v1/audio/speech'],
-    'tts-1-hd': ['/v1/audio/speech'],
-    'gpt-3.5-turbo-instruct': ['/v1/completions (Legacy)'],
-    'babbage-002': ['/v1/completions (Legacy)', '/v1/fine_tuning/jobs'],
-    'davinci-002': ['/v1/completions (Legacy)', '/v1/fine_tuning/jobs'],
-    'text-embedding-3-small': ['/v1/embeddings'],
-    'text-embedding-3-large': ['/v1/embeddings'],
-    'text-embedding-ada-002': ['/v1/embeddings'],
-    'text-moderation-stable': ['/v1/moderations'],
-    'text-moderation-latest': ['/v1/moderations'],
-    'dall-e-2': ['/v1/images/generations'],
-    'dall-e-3': ['/v1/images/generations'],
-  };
+
+export const ModelEndpointMapping: Record<string, OpenAiEndpoint[]> = {
+  'gpt-4.1-nano': ['/v1/assistants', '/v1/chat/completions'],
+  'gpt-4.1-preview': ['/v1/assistants', '/v1/chat/completions'],
+  'gpt-4.1': ['/v1/assistants', '/v1/chat/completions', '/v1/fine_tuning/jobs'],
+  'gpt-4o-mini': [
+    '/v1/assistants',
+    '/v1/chat/completions',
+    '/v1/fine_tuning/jobs',
+  ],
+  'gpt-4': ['/v1/assistants', '/v1/chat/completions', '/v1/fine_tuning/jobs'],
+  'gpt-3.5-turbo': [
+    '/v1/assistants',
+    '/v1/chat/completions',
+    '/v1/fine_tuning/jobs',
+  ],
+  'gpt-4o': ['/v1/assistants', '/v1/chat/completions', '/v1/fine_tuning/jobs'],
+  'whisper-1': ['/v1/audio/transcriptions', '/v1/audio/translations'],
+  'tts-1': ['/v1/audio/speech'],
+  'tts-1-hd': ['/v1/audio/speech'],
+  'gpt-3.5-turbo-instruct': ['/v1/completions (Legacy)'],
+  'babbage-002': ['/v1/completions (Legacy)', '/v1/fine_tuning/jobs'],
+  'davinci-002': ['/v1/completions (Legacy)', '/v1/fine_tuning/jobs'],
+  'text-embedding-3-small': ['/v1/embeddings'],
+  'text-embedding-3-large': ['/v1/embeddings'],
+  'text-embedding-ada-002': ['/v1/embeddings'],
+  'text-moderation-stable': ['/v1/moderations'],
+  'text-moderation-latest': ['/v1/moderations'],
+  'dall-e-2': ['/v1/images/generations'],
+  'dall-e-3': ['/v1/images/generations'],
+};
 
 export type OpenAiChatMessage = {
   role: 'user' | 'assistant' | 'system' | 'tool';

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,6 @@ import { LLMProviders } from '@/llm/provider/base';
 import { OpenAIProvider } from '@/llm/provider/openai';
 import {
   fetchAvailableModels,
-  getDefaultChatModels,
   getDefaultModel,
   OpenAiTextModelNames,
 } from '@/llm/types/openai';
@@ -19,8 +18,8 @@ const fetchAvailableModelsMain = fetchAvailableModels; // CLASP workaround
 
 const AppMenuName = 'SheetsAI Menu';
 const AppMenuMapping = new Map<string, string>([
-  ['Set API Keys', setLLmApiKeys.name],
-  ['Get Help', showHelpSidebar.name],
+  ['Settings', setLLmApiKeys.name],
+  ['Help', showHelpSidebar.name],
   ['Clear Cache', clearSheetsAICache.name],
 ]);
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,13 +1,21 @@
 import { AnalyticsConstants } from '@/analytics/constants';
 import { PostHogAnalytics } from '@/analytics/posthog';
-import { Utils, SheetsAIError } from '@/common/utils';
+import { SheetsAIError, Utils } from '@/common/utils';
 import { LLMProviders } from '@/llm/provider/base';
 import { OpenAIProvider } from '@/llm/provider/openai';
+import {
+  fetchAvailableModels,
+  getDefaultChatModels,
+  getDefaultModel,
+  OpenAiTextModelNames,
+} from '@/llm/types/openai';
 import { SecretService } from '@/sheets/secrets';
 import { LLMUsageService } from '@/sheets/storage/llm-usage';
 import { UIManager } from '@/ui/UIManager';
 
 const acMain = new AnalyticsConstants();
+const getDefaultModelMain = getDefaultModel; // CLASP workaround
+const fetchAvailableModelsMain = fetchAvailableModels; // CLASP workaround
 
 const AppMenuName = 'SheetsAI Menu';
 const AppMenuMapping = new Map<string, string>([
@@ -19,7 +27,7 @@ const AppMenuMapping = new Map<string, string>([
 const CACHE_TTL_SECONDS = 21600; // 6 hours
 
 /**
- * Generates text using a large language model. Defaults to GPT-4o. Requires API key to be set in the `SheetsAI Menu > Set API Keys` menu.
+ * Generates text using a large language model. Uses the model configured in settings or defaults to gpt-4.1-nano. Requires API key to be set in the `SheetsAI Menu > Set API Keys` menu.
  * @param {string} query The query for the model, i.e. "What is the capital of the United States?" or "Is the animal in this cell a feline?"
  * @param {string | undefined} context [optional] If provided, will add this context into the query, i.e. if asking "Is the animal in this cell a feline?" and the context is a cell containing the word "Cat" or "dog".
  * @returns {string} The generated text from the model.
@@ -29,12 +37,6 @@ export async function SHEETS_AI(
   query: string,
   context?: string
 ): Promise<string | void> {
-  // Track function call (without the query content)
-  const analytics = PostHogAnalytics.getInstance();
-  analytics.track(acMain.EVENTS.FUNCTION_CALL, {
-    hasContext: !!context,
-  });
-
   // Create a cache key based on input parameters
   const cacheKey = `SHEETS_AI_${Utils.cyrb64Hash(query)}_${Utils.cyrb64Hash(
     context || ''
@@ -43,13 +45,16 @@ export async function SHEETS_AI(
   // Get the cache
   const cache = CacheService.getUserCache();
   const cachedResult = cache.get(cacheKey);
+  let completionTextLength: number = 0;
+  let selectedModel: string | null = null;
 
   // Return cached result if available
   if (cachedResult) {
     return cachedResult;
   }
 
-  const apiKey = new SecretService().getSecret('USER_OPENAI_KEY');
+  const secretService = new SecretService();
+  const apiKey = secretService.getSecret('USER_OPENAI_KEY');
   if (!apiKey) {
     try {
       UIManager.showAlert(
@@ -62,6 +67,13 @@ export async function SHEETS_AI(
     } catch (error) {
       // Handle case when UI operations aren't allowed
       return 'Error: SheetsAI API key not set. Please set it via SheetsAI Menu.';
+    } finally {
+      // Track function call (without the query content)
+      const analytics = PostHogAnalytics.getInstance();
+      analytics.track(acMain.EVENTS.FUNCTION_CALL, {
+        hasContext: !!context,
+        missingApiKey: !apiKey,
+      });
     }
     return;
   }
@@ -70,7 +82,12 @@ export async function SHEETS_AI(
   }
   const usageService = new LLMUsageService();
   try {
-    const openai = new OpenAIProvider('gpt-4o-mini', apiKey);
+    // Get user's preferred model or use default
+    const userModel =
+      (secretService.getSecret('USER_OPENAI_MODEL') as OpenAiTextModelNames) ||
+      getDefaultModelMain('openai');
+
+    const openai = new OpenAIProvider(userModel, apiKey);
     const completion = await openai.generateChatCompletion({
       messages: [
         {
@@ -85,6 +102,8 @@ export async function SHEETS_AI(
 
     // Cache the result for 6 hours
     cache.put(cacheKey, completion.text, CACHE_TTL_SECONDS);
+    completionTextLength = completion.text.length;
+    selectedModel = userModel;
 
     return completion.text;
   } catch (error: Error | any) {
@@ -92,6 +111,15 @@ export async function SHEETS_AI(
     throw new SheetsAIError(
       'Failed to make Open AI call: please make sure your API key is correct!'
     );
+  } finally {
+    // Track function call (without the query content)
+    const analytics = PostHogAnalytics.getInstance();
+    analytics.track(acMain.EVENTS.FUNCTION_CALL, {
+      hasContext: !!context,
+      queryLength: query.length,
+      responseLength: completionTextLength,
+      selectedModel: selectedModel,
+    });
   }
 }
 
@@ -207,29 +235,47 @@ export function listLLMProviders(): Map<LLMProviders, string> {
 export function getStoredApiKey(provider: LLMProviders): {
   key: string;
   instructionUrl: string;
+  model?: string;
 } {
   const secretService = new SecretService();
   const instructionUrl = getApiKeyInstructions(provider);
   switch (provider) {
     case 'openai':
       const key = secretService.getSecret('USER_OPENAI_KEY');
+      const model =
+        secretService.getSecret('USER_OPENAI_MODEL') ||
+        getDefaultModelMain(provider);
       const returnKey = key ? key.substring(0, 16) + '********' : '';
-      return { key: returnKey, instructionUrl };
+      return { key: returnKey, instructionUrl, model };
     default:
       throw new SheetsAIError('Invalid LLM Provider selected: ' + provider);
   }
 }
 
-// Function to set the OpenAI API key
-export function saveApiKey(provider: LLMProviders, key: string) {
+// Function to set the OpenAI API key and model
+export function saveApiKey(
+  provider: LLMProviders,
+  key?: string,
+  model?: string
+) {
   switch (provider) {
     case 'openai':
       const secretService = new SecretService();
-      secretService.setSecret('USER_OPENAI_KEY', key);
+      if (key) {
+        secretService.setSecret('USER_OPENAI_KEY', key);
+      }
+
+      // Save model if provided
+      if (model) {
+        secretService.setSecret('USER_OPENAI_MODEL', model);
+      }
 
       // Track API key set event (without the key itself)
       const analytics = PostHogAnalytics.getInstance();
-      analytics.track(acMain.EVENTS.API_KEY_SET, { provider });
+      analytics.track(acMain.EVENTS.API_KEY_SET, {
+        provider,
+        modelChanged: !!model,
+      });
 
       return `OpenAI API Key saved successfully!`;
     default:
@@ -283,4 +329,11 @@ function setAnalyticsStatus(optOut: boolean): boolean {
   analytics.setOptOut(optOut);
 
   return optOut;
+}
+
+// Get available models from OpenAI API
+export async function getAvailableModels(
+  provider: LLMProviders
+): Promise<string[]> {
+  return fetchAvailableModelsMain(provider);
 }

--- a/src/sheets/secrets.ts
+++ b/src/sheets/secrets.ts
@@ -1,7 +1,8 @@
-type SecretKey = 'USER_OPENAI_KEY';
+type SecretKey = 'USER_OPENAI_KEY' | 'USER_OPENAI_MODEL';
 
 type SecretMap = {
   USER_OPENAI_KEY: string;
+  USER_OPENAI_MODEL: string;
 };
 
 export class SecretService {

--- a/src/ui/UIManager.ts
+++ b/src/ui/UIManager.ts
@@ -78,7 +78,7 @@ export class UIManager {
       'ui/html/SetLLMProvider.html',
       {
         width: 600,
-        height: 400,
+        height: 470,
       }
     );
     this.showModalDialog(htmlOutput, 'Set your LLM API Key(s)');

--- a/src/ui/UIManager.ts
+++ b/src/ui/UIManager.ts
@@ -81,7 +81,7 @@ export class UIManager {
         height: 470,
       }
     );
-    this.showModalDialog(htmlOutput, 'Set your LLM API Key(s)');
+    this.showModalDialog(htmlOutput, 'SheetsAI Settings');
   }
 
   /**

--- a/src/ui/html/SetLLMProvider.html
+++ b/src/ui/html/SetLLMProvider.html
@@ -32,6 +32,7 @@
         box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.2);
       }
       input[type='text'],
+      input[type='password'],
       select {
         flex-grow: 1;
         border: none;
@@ -118,7 +119,6 @@
   </head>
   <body>
     <div class="container">
-      <h2>LLM API Key Configuration</h2>
       <form id="apiForm">
         <div class="input-group">
           <label for="provider">Select Provider</label>
@@ -167,22 +167,36 @@
           </div>
           <div class="input-wrapper">
             <input
-              type="text"
+              type="password"
               id="api-key"
               name="api-key"
               required
               placeholder="Enter your API key (i.e., sk-...)"
               aria-label="API Key"
+              autocomplete="off"
+              spellcheck="false"
             />
           </div>
           <p class="description">
             Your secret API key. Keep this safe and do not share it publicly.
           </p>
         </div>
-
-        <button type="submit" id="saveButton" class="primary-button">
-          Save
-        </button>
+        <div class="button-container">
+          <button
+            type="button"
+            id="closeButton"
+            class="ui-button secondary-button"
+          >
+            Close
+          </button>
+          <button
+            type="submit"
+            id="saveButton"
+            class="ui-button primary-button"
+          >
+            Save
+          </button>
+        </div>
       </form>
     </div>
 
@@ -194,6 +208,7 @@
         const apiKeyElement = document.getElementById('api-key');
         const currentApiKeyElement = document.getElementById('current-api-key');
         const saveButton = document.getElementById('saveButton');
+        const closeButton = document.getElementById('closeButton');
         const modelLoadingElement = document.getElementById('model-loading');
         const refreshModelsButton = document.getElementById('refresh-models');
 
@@ -210,6 +225,10 @@
         // Refresh models button
         refreshModelsButton.addEventListener('click', function () {
           loadAvailableModels(providerElement.value);
+        });
+
+        closeButton.addEventListener('click', function () {
+          google.script.host.close();
         });
 
         // Form submission
@@ -238,11 +257,6 @@
                 SheetsAI.showToast(
                   'Settings saved successfully! You can now close this window.'
                 );
-
-                // Uncomment to close the modal after a short delay
-                // setTimeout(function () {
-                //   google.script.host.close();
-                // }, 1500);
               },
               onFailure: function (error) {
                 SheetsAI.showToast('Failed to save API key: ' + error, 'error');

--- a/src/ui/html/SetLLMProvider.html
+++ b/src/ui/html/SetLLMProvider.html
@@ -85,6 +85,35 @@
         background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 24 24' fill='none' stroke='%232563eb' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6'/%3E%3Cpolyline points='15 3 21 3 21 9'/%3E%3Cline x1='10' y1='14' x2='21' y2='3'/%3E%3C/svg%3E");
         background-repeat: no-repeat;
       }
+      .loading-spinner {
+        display: inline-block;
+        width: 16px;
+        height: 16px;
+        border: 2px solid rgba(0, 0, 0, 0.1);
+        border-left-color: #09f;
+        border-radius: 50%;
+        animation: spin 1s linear infinite;
+        margin-left: 8px;
+      }
+      @keyframes spin {
+        to {
+          transform: rotate(360deg);
+        }
+      }
+      .refresh-models {
+        background-color: transparent;
+        border: none;
+        color: #2563eb;
+        cursor: pointer;
+        font-size: 14px;
+        padding: 0;
+        margin-left: 8px;
+        display: inline-flex;
+        align-items: center;
+      }
+      .refresh-models:hover {
+        text-decoration: underline;
+      }
     </style>
   </head>
   <body>
@@ -107,6 +136,28 @@
         </div>
 
         <div class="input-group">
+          <label for="model"
+            >Default Model <span id="model-loading"></span
+          ></label>
+          <div class="input-wrapper">
+            <select
+              id="model"
+              name="model"
+              required
+              aria-label="Select Default Model"
+            >
+              <!-- Models will be populated dynamically -->
+            </select>
+          </div>
+          <p class="description">
+            Select the default model to use for queries.
+            <button type="button" class="refresh-models" id="refresh-models">
+              Refresh models
+            </button>
+          </p>
+        </div>
+
+        <div class="input-group">
           <label for="api-key">API Key</label>
           <div class="hints">
             <div class="api-key-info">
@@ -120,7 +171,7 @@
               id="api-key"
               name="api-key"
               required
-              placeholder="Enter your API key (i.e., sk_test_...)"
+              placeholder="Enter your API key (i.e., sk-...)"
               aria-label="API Key"
             />
           </div>
@@ -139,14 +190,26 @@
     <script>
       document.addEventListener('DOMContentLoaded', function () {
         const providerElement = document.getElementById('provider');
+        const modelElement = document.getElementById('model');
+        const apiKeyElement = document.getElementById('api-key');
+        const currentApiKeyElement = document.getElementById('current-api-key');
         const saveButton = document.getElementById('saveButton');
+        const modelLoadingElement = document.getElementById('model-loading');
+        const refreshModelsButton = document.getElementById('refresh-models');
 
         // Initial API key fetch
         getCurrentApiKey(providerElement.value);
+        loadAvailableModels(providerElement.value);
 
         // Provider change event
         providerElement.addEventListener('change', function (e) {
           getCurrentApiKey(e.target.value);
+          loadAvailableModels(e.target.value);
+        });
+
+        // Refresh models button
+        refreshModelsButton.addEventListener('click', function () {
+          loadAvailableModels(providerElement.value);
         });
 
         // Form submission
@@ -155,9 +218,11 @@
           .addEventListener('submit', function (e) {
             e.preventDefault();
             const provider = providerElement.value;
-            const apiKey = document.getElementById('api-key').value;
-
-            if (!provider || !apiKey) {
+            const model = modelElement.value;
+            const apiKey =
+              apiKeyElement.value || currentApiKeyElement.textContent;
+            const redactedCurrentApiKey = currentApiKeyElement.textContent;
+            if (!provider || (!apiKey && !redactedCurrentApiKey) || !model) {
               SheetsAI.showToast('Please fill in all fields', 'error');
               return;
             }
@@ -173,10 +238,10 @@
                 saveButton.textContent = 'Saved';
                 SheetsAI.showToast('API key saved successfully!');
 
-                // Close the modal after a short delay
-                setTimeout(function () {
-                  google.script.host.close();
-                }, 1500);
+                // Uncomment to close the modal after a short delay
+                // setTimeout(function () {
+                //   google.script.host.close();
+                // }, 1500);
               },
               onFailure: function (error) {
                 SheetsAI.showToast('Failed to save API key: ' + error, 'error');
@@ -184,8 +249,74 @@
             });
 
             // Call the function with parameters
-            saveApiKeyFn(provider, apiKey);
+            saveApiKeyFn(provider, apiKey, model);
           });
+
+        /**
+         * Load available models from the OpenAI API
+         */
+        function loadAvailableModels(provider) {
+          // Show loading spinner
+          modelLoadingElement.innerHTML = '<div class="loading-spinner"></div>';
+
+          const getAvailableModelsFn = SheetsAI.callServer(
+            'getAvailableModels',
+            {
+              onSuccess: function (models) {
+                // Clear existing options except the default one
+                while (modelElement.options.length > 0) {
+                  modelElement.remove(0);
+                }
+
+                // Add new options
+                models.forEach(function (model) {
+                  const option = document.createElement('option');
+                  option.value = model;
+                  option.textContent = model;
+                  modelElement.appendChild(option);
+                });
+
+                // Remove loading spinner
+                modelLoadingElement.innerHTML = '';
+
+                // If a model was previously selected, try to reselect it
+                const storedModel = getCurrentModel();
+                if (storedModel) {
+                  for (let i = 0; i < modelElement.options.length; i++) {
+                    if (modelElement.options[i].value === storedModel) {
+                      modelElement.selectedIndex = i;
+                      break;
+                    }
+                  }
+                }
+
+                SheetsAI.showToast('Models refreshed successfully');
+              },
+              onFailure: function (error) {
+                // Remove loading spinner
+                modelLoadingElement.innerHTML = '';
+                SheetsAI.showToast('Failed to load models: ' + error, 'error');
+              },
+            }
+          );
+
+          // Call the function with parameters
+          getAvailableModelsFn(provider);
+        }
+
+        /**
+         * Get current selected model from local storage
+         */
+        function getCurrentModel() {
+          return localStorage.getItem('sheetsai_current_model');
+        }
+
+        /**
+         * Set current selected model to local storage
+         */
+        function setCurrentModel(model) {
+          localStorage.setItem('sheetsai_current_model', model);
+        }
       });
 
       /**
@@ -195,6 +326,7 @@
         const getStoredApiKeyFn = SheetsAI.callServer('getStoredApiKey', {
           onSuccess: function (data) {
             const storedKey = data.key;
+            const storedModel = data.model;
             const instructionUrl = data.instructionUrl;
 
             // Update the current key display
@@ -202,6 +334,40 @@
             keyElement.textContent = storedKey
               ? 'Current key is: ' + storedKey
               : 'No key is currently set for this provider.';
+
+            const apiKeyElement = document.getElementById('api-key');
+            if (storedKey) {
+              apiKeyElement.required = false;
+            }
+
+            // Update the selected model if available
+            if (storedModel) {
+              const modelElement = document.getElementById('model');
+
+              // First check if the model exists in the dropdown
+              let modelExists = false;
+              for (let i = 0; i < modelElement.options.length; i++) {
+                if (modelElement.options[i].value === storedModel) {
+                  modelElement.selectedIndex = i;
+                  modelExists = true;
+                  break;
+                }
+              }
+
+              // If the model doesn't exist in the dropdown, add it
+              if (!modelExists) {
+                const option = document.createElement('option');
+                option.value = storedModel;
+                option.textContent = storedModel;
+                modelElement.appendChild(option);
+
+                // Select the newly added option
+                modelElement.value = storedModel;
+              }
+
+              // Store in local storage
+              localStorage.setItem('sheetsai_current_model', storedModel);
+            }
 
             // Update the instructions link
             const instructionsElement = document.getElementById(
@@ -212,6 +378,16 @@
             } else {
               instructionsElement.innerHTML = '';
             }
+
+            // // If we have an API key, try to load models
+            // const apiKeyElement = document.getElementById('api-key');
+            // if (storedKey && storedKey.includes('*')) {
+            //   // We need to wait for the user to enter their API key again
+            //   // since we don't store the full key for security reasons
+            // } else if (apiKeyElement.value) {
+            //   loadAvailableModels(apiKeyElement.value);
+            // }
+            return storedKey;
           },
           onFailure: function (error) {
             console.error('Failed to get API key:', error);

--- a/src/ui/html/SetLLMProvider.html
+++ b/src/ui/html/SetLLMProvider.html
@@ -219,8 +219,7 @@
             e.preventDefault();
             const provider = providerElement.value;
             const model = modelElement.value;
-            const apiKey =
-              apiKeyElement.value || currentApiKeyElement.textContent;
+            const apiKey = apiKeyElement.value;
             const redactedCurrentApiKey = currentApiKeyElement.textContent;
             if (!provider || (!apiKey && !redactedCurrentApiKey) || !model) {
               SheetsAI.showToast('Please fill in all fields', 'error');
@@ -236,7 +235,9 @@
                 getCurrentApiKey(provider);
                 saveButton.classList.add('completed');
                 saveButton.textContent = 'Saved';
-                SheetsAI.showToast('API key saved successfully!');
+                SheetsAI.showToast(
+                  'Settings saved successfully! You can now close this window.'
+                );
 
                 // Uncomment to close the modal after a short delay
                 // setTimeout(function () {

--- a/src/ui/html/SideHelpBar.html
+++ b/src/ui/html/SideHelpBar.html
@@ -209,7 +209,7 @@
          number: '2',
          title: 'Set your API Key',
          description: 'Navigate to the settings and input your OpenAI API key securely (you can use the button below).',
-         content: '<div class="button-container"><button class="primary-button" onclick="google.script.run.setLLmApiKeys()">Set API Key</button></div>'
+         content: '<div class="button-container"><button class="ui-button primary-button" onclick="google.script.run.setLLmApiKeys()">Set API Key</button></div>'
       }; ?>
       <?!= include('ui/html/components/Step', stepSetKey); ?>
       

--- a/src/ui/html/SideHelpBar.html
+++ b/src/ui/html/SideHelpBar.html
@@ -151,7 +151,7 @@
       }
 
       input:checked + .slider:before {
-        transform: translateX(10px);
+        transform: translateX(18px);
       }
       
       /* Consistent text sizes throughout */

--- a/src/ui/html/components/Styles.html
+++ b/src/ui/html/components/Styles.html
@@ -85,39 +85,33 @@
   }
 
   /* Primary button - for main actions */
-  .primary-button {
+  .ui-button {
     background-color: #111111;
-    color: white;
+    color: #fff;
     width: 100%;
     padding: 12px 20px;
     box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+    border: 1.5px solid #111111;
   }
 
-  .primary-button:hover:not(:disabled) {
-    background-color: #000000;
+  .ui-button:hover:not(:disabled) {
     transform: translateY(-1px);
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   }
 
-  .primary-button:active:not(:disabled) {
+  .ui-button:active:not(:disabled) {
     transform: translateY(0);
     box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+  }
+  .primary-button {
+    background-color: #111111;
+    color: #fff;
   }
 
   /* Secondary button - for secondary actions */
   .secondary-button {
-    background-color: #f5f5f5;
+    background-color: #fff;
     color: #111111;
-    border: 1px solid #e5e5e5;
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    font-size: 13px;
-    padding: 8px 14px;
-  }
-
-  .secondary-button:hover:not(:disabled) {
-    background-color: #e9e9e9;
   }
 
   /* Copy button for code snippets */

--- a/src/ui/html/components/Styles.html
+++ b/src/ui/html/components/Styles.html
@@ -8,7 +8,7 @@
     display: flex;
     justify-content: center;
     align-items: flex-start;
-    padding: 20px;
+    padding: 0px;
     margin: 0;
     min-height: 100vh;
   }
@@ -20,7 +20,6 @@
     border-radius: 12px;
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
     width: 100%;
-    max-width: 500px;
     box-sizing: border-box;
   }
 


### PR DESCRIPTION
* This release introduces a redesigned Settings modal and extended OpenAI model support.
* Adds ability to select a default OpenAI model per user
* Dynamically fetches available models from the OpenAI API with fallback defaults
* Persists selected model alongside API key via SecretService
* Updates model endpoint/type mappings to reflect latest OpenAI model taxonomy (e.g., gpt-4.1, gpt-4o, etc.)
* Implements graceful fallback to `gpt-4.1-nano` if no model is selected
* Updates `SHEETS_AI` and `getStoredApiKey` to use user-specified models
* Refactors and expands UI:
  * Adds model dropdown with refresh button
  * Switches API key input to password type
  * Adds close button and loading spinner
  * General style and accessibility improvements
  * Also includes minor analytics enhancements and UI polish.

Closes: #model-selection, #api-key-ui, #model-fetch